### PR TITLE
Add CI/CD workflow for backend and frontend, and include 'rest-framework' in installed apps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI/CD for RubikLog
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  backend:
+    name: Backend CI
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: rubiklogdb
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+        ports:
+          - 5432:5432
+    env:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/rubiklogdb
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run migrations
+        run: |
+          python RubikLog/manage.py migrate
+
+      - name: Run backend tests
+        run: |
+          python RubikLog/manage.py test
+
+  frontend:
+    name: Frontend CI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+
+      - name: Install dependencies
+        working-directory: RubikLog/frontend
+        run: |
+          npm ci
+
+      - name: Run frontend tests
+        working-directory: RubikLog/frontend
+        run: |
+          npm test -- --watchAll=false
+
+      - name: Build frontend
+        working-directory: RubikLog/frontend
+        run: |
+          npm run build

--- a/RubikLog/RubikLog/settings.py
+++ b/RubikLog/RubikLog/settings.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'tracker',                  # RubikLog app
     'corsheaders',              # Enable CORS for frontend-backend communication
+    'rest-framework'
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
This pull request introduces a CI/CD pipeline for the RubikLog project and makes a small change to the Django settings to include a new app.

CI/CD Pipeline Setup:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR1-R78): Added a new GitHub Actions workflow for CI/CD, which includes separate jobs for backend and frontend testing and building. The backend job sets up a PostgreSQL service, installs dependencies, runs migrations, and executes tests. The frontend job installs dependencies, runs tests, and builds the frontend.

Django Settings Update:

* [`RubikLog/RubikLog/settings.py`](diffhunk://#diff-e325c18e3819ade20a58c8e8aaed54461b947ce1e8349c136aa047a9024fc69cR47): Added `'rest-framework'` to the `INSTALLED_APPS` list to include the Django REST framework in the project.