### PR TITLE
Add CI/CD workflow for backend and frontend, and include 'rest-framework' in installed apps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,11 @@ jobs:
         run: |
           npm ci
 
+      - name: Install jest-dom
+        working-directory: RubikLog/frontend
+        run: |
+          npm install @testing-library/jest-dom --save-dev
+
       - name: Run frontend tests
         working-directory: RubikLog/frontend
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI/CD for RubikLog
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  backend:
+    name: Backend CI
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: rubiklogdb
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+        ports:
+          - 5432:5432
+    env:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/rubiklogdb
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run migrations
+        run: |
+          python RubikLog/manage.py migrate
+
+      - name: Run backend tests
+        run: |
+          python RubikLog/manage.py test
+
+  frontend:
+    name: Frontend CI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+
+      - name: Install dependencies
+        working-directory: RubikLog/frontend
+        run: |
+          npm ci
+
+      - name: Run frontend tests
+        working-directory: RubikLog/frontend
+        run: |
+          npm test -- --watchAll=false
+
+      - name: Build frontend
+        working-directory: RubikLog/frontend
+        run: |
+          npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         image: postgres:14
         env:
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
+          POSTGRES_PASSWORD: shreyuu
           POSTGRES_DB: rubiklogdb
         options: >-
           --health-cmd="pg_isready -U postgres"
@@ -27,7 +27,7 @@ jobs:
         ports:
           - 5432:5432
     env:
-      DATABASE_URL: postgres://postgres:postgres@localhost:5432/rubiklogdb
+      DATABASE_URL: postgres://postgres:shreyuu@localhost:5432/rubiklogdb
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/RubikLog/RubikLog/settings.py
+++ b/RubikLog/RubikLog/settings.py
@@ -44,7 +44,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'tracker',                  # RubikLog app
     'corsheaders',              # Enable CORS for frontend-backend communication
-    'rest-framework'
+    'rest_framework'
 ]
 
 MIDDLEWARE = [

--- a/RubikLog/RubikLog/settings.py
+++ b/RubikLog/RubikLog/settings.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'tracker',                  # RubikLog app
     'corsheaders',              # Enable CORS for frontend-backend communication
+    'rest-framework'
 ]
 
 MIDDLEWARE = [

--- a/RubikLog/frontend/package.json
+++ b/RubikLog/frontend/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "autoprefixer": "^10.4.20",
     "postcss": "^8.5.1",
-    "tailwindcss": "^3.4.17"
+    "tailwindcss": "^3.4.17",
+    "@testing-library/jest-dom": "^5.16.5"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,6 @@ dnspython==2.7.0
 psycopg2==2.9.10
 psycopg2-binary==2.9.10
 pymongo==4.10.1
+python-decouple==3.8
 pytz==2024.2
 sqlparse==0.5.3


### PR DESCRIPTION
This pull request introduces a CI/CD pipeline for the RubikLog project, adds a new dependency to the backend, and updates the frontend dependencies. The most important changes include setting up the CI/CD workflows for both backend and frontend, adding the `rest_framework` to Django settings, and updating the frontend's `package.json` to include `@testing-library/jest-dom`.

CI/CD setup:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR1-R83): Added a CI/CD workflow configuration for the RubikLog project, including jobs for backend and frontend testing and building.

Backend updates:

* [`RubikLog/RubikLog/settings.py`](diffhunk://#diff-e325c18e3819ade20a58c8e8aaed54461b947ce1e8349c136aa047a9024fc69cR47): Added `rest_framework` to the installed apps in Django settings.

Frontend updates:

* [`RubikLog/frontend/package.json`](diffhunk://#diff-4225a2f8fd84d28d987064d1f26348ffcad8283d58e006cc38f4be6ca341f383L39-R40): Added `@testing-library/jest-dom` to the `devDependencies`.