### PR TITLE
Add Babel plugin for private property proposal and update devDependencies in package.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
         run: |
           npm ci
           npm install @testing-library/react --save-dev
+          npm install @babel/plugin-proposal-private-property-in-object --save-dev
 
       - name: Run frontend tests
         working-directory: RubikLog/frontend

--- a/RubikLog/frontend/package.json
+++ b/RubikLog/frontend/package.json
@@ -35,6 +35,9 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+    "@testing-library/react": "^13.0.0",
+    "jest": "^29.7.0",
+    "react-scripts": "5.0.1",
     "@jest/expect-utils": "^29.7.0",
     "@jest/schemas": "^29.6.3",
     "@jest/types": "^29.6.3",


### PR DESCRIPTION
This pull request includes updates to the dependencies and configurations for the frontend tests in the `RubikLog` project. The most important changes include adding new dependencies and modifying the CI workflow configuration.

Dependency updates:

* [`RubikLog/frontend/package.json`](diffhunk://#diff-4225a2f8fd84d28d987064d1f26348ffcad8283d58e006cc38f4be6ca341f383R38-R40): Added `@testing-library/react`, `jest`, and `react-scripts` to the `devDependencies`.

CI workflow configuration:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR70): Added `@babel/plugin-proposal-private-property-in-object` to the list of packages installed during the CI setup.