### PR TITLE
Add .vscode/settings.json to .gitignore and create RubikLogDB.session sql for tracker_solve queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 rubiklogenv
 RubikLog/.env
 .DS_Store
+.vscode/settings.json

--- a/RubikLogDB.session.sql
+++ b/RubikLogDB.session.sql
@@ -1,0 +1,10 @@
+-- Display all columns and rows from tracker_solve table
+SELECT *
+FROM tracker_solve;
+-- For more detailed information about the table structure:
+SELECT column_name,
+    data_type,
+    character_maximum_length
+FROM information_schema.columns
+WHERE table_name = 'tracker_solve'
+ORDER BY ordinal_position;


### PR DESCRIPTION
This pull request includes a new SQL script to query and display information from the `tracker_solve` table in the `RubikLogDB` database. The changes are focused on retrieving all columns and rows from the table and providing detailed information about the table's structure.

SQL script additions:

* [`RubikLogDB.session.sql`](diffhunk://#diff-c88d489be470e1125c06f261303f4e519a97680d4496012c5cf3ab2121e8caafR1-R10): Added a query to select all columns and rows from the `tracker_solve` table. Also added a query to retrieve column names, data types, and character maximum lengths from the `information_schema.columns` for the `tracker_solve` table, ordered by their ordinal position.