### PR TITLE
Add color detection to SolveList; integrate CubeScrambleDetector to extract colors from provided cube images.

### DIFF
--- a/RubikLog/tracker/views.py
+++ b/RubikLog/tracker/views.py
@@ -53,6 +53,7 @@ class SolveList(APIView):
                         status=status.HTTP_400_BAD_REQUEST
                     )
                 image_data = base64.b64decode(cube_image.split(',')[1])
+                detected_colors = self.detector.detect_colors(image_data)
                 data['detected_colors'] = detected_colors
                 
                 # Generate scramble from detected colors


### PR DESCRIPTION
This pull request introduces a change to the `post` method in `RubikLog/tracker/views.py` to enhance functionality by adding color detection for cube images.

Key change:

* [`RubikLog/tracker/views.py`](diffhunk://#diff-50265360f1ae2b115a98b00fe2300d4d9544e39ef9fadde6b10a966b5dfdf854R56): Added a call to `self.detector.detect_colors(image_data)` to process the base64-decoded cube image and detect colors. The detected colors are then included in the response data under the `detected_colors` key.