### PR TITLE
feat: Add Vercel configuration for deployment and update allowed hosts in settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ RubikLog/.env
 __pycache__/
 *.pyc
 rubiklogenv-py311
+.vercel

--- a/RubikLog/RubikLog/settings.py
+++ b/RubikLog/RubikLog/settings.py
@@ -31,6 +31,7 @@ SECRET_KEY = os.getenv('DJANGO_SECRET_KEY', 'django-insecure-ld!$v-9h%j)4f*2w$q5
 DEBUG = os.getenv('DJANGO_DEBUG', 'True') == 'True'
 
 ALLOWED_HOSTS = os.getenv('DJANGO_ALLOWED_HOSTS', '').split(',') if not DEBUG else ['localhost', '127.0.0.1']
+ALLOWED_HOSTS += ['.vercel.app']
 
 
 # Application definition
@@ -66,6 +67,7 @@ MIDDLEWARE = [
 
 # Allow communication from React frontend
 CORS_ALLOWED_ORIGINS = ["http://localhost:3000"]
+CORS_ALLOWED_ORIGINS += ['https://*.vercel.app']
 
 # Allow larger file uploads
 DATA_UPLOAD_MAX_MEMORY_SIZE = 5242880  # 5MB

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,32 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "RubikLog/wsgi.py",
+      "use": "@vercel/python"
+    },
+    {
+      "src": "RubikLog/frontend/package.json",
+      "use": "@vercel/static-build",
+      "config": { "distDir": "build" }
+    }
+  ],
+  "routes": [
+    {
+      "src": "/api/(.*)",
+      "dest": "RubikLog/wsgi.py"
+    },
+    {
+      "src": "/admin/(.*)",
+      "dest": "RubikLog/wsgi.py"
+    },
+    {
+      "src": "/static/(.*)",
+      "dest": "RubikLog/frontend/build/static/$1"
+    },
+    {
+      "src": "/(.*)",
+      "dest": "RubikLog/frontend/build/$1"
+    }
+  ]
+}


### PR DESCRIPTION
This pull request introduces changes to support deployment on Vercel by updating the Django settings and adding a `vercel.json` configuration file. The most important changes include extending `ALLOWED_HOSTS` and `CORS_ALLOWED_ORIGINS` in the Django settings, and defining build and routing rules for Vercel.

### Updates to Django settings:

* [`RubikLog/RubikLog/settings.py`](diffhunk://#diff-e325c18e3819ade20a58c8e8aaed54461b947ce1e8349c136aa047a9024fc69cR34): Added `.vercel.app` to `ALLOWED_HOSTS` to allow requests from Vercel-hosted domains.
* [`RubikLog/RubikLog/settings.py`](diffhunk://#diff-e325c18e3819ade20a58c8e8aaed54461b947ce1e8349c136aa047a9024fc69cR70): Updated `CORS_ALLOWED_ORIGINS` to include `https://*.vercel.app` for cross-origin requests from Vercel-hosted React frontends.

### Vercel deployment configuration:

* [`vercel.json`](diffhunk://#diff-a3265310f552fb66876e8bfe8809737e59e5ba946bdf39138b44d9baf4e21240R1-R32): Added a configuration file specifying build rules for the Django backend and React frontend, along with routing rules for API, admin, static files, and frontend assets.