### PR TITLE
fix: update .gitignore to include frontend/.env and modify API_URL for production environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ rubiklogenv-py311
 build/
 dist/
 node_modules/
+frontend/.env

--- a/RubikLog/settings.py
+++ b/RubikLog/settings.py
@@ -104,6 +104,7 @@ DATABASES = {
         'PASSWORD': config('POSTGRES_PASSWORD'),
         'HOST': config('POSTGRES_HOST'),
         'PORT': config('POSTGRES_PORT', cast=int),
+        'CONN_MAX_AGE': 600,  # Connection pooling: keep connections alive for 10 minutes
     }
 }
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,9 +7,7 @@ import { generateScrambleFromColors } from "./utils/cubeNotation";
 import ScrambleVisualizer from './components/ScrambleVisualizer';
 
 // Update API_URL to use relative path
-const API_URL = process.env.NODE_ENV === 'production'
-    ? '/api'
-    : 'http://127.0.0.1:8000/api';
+const API_URL = process.env.REACT_APP_API_URL || 'http://127.0.0.1:8000/api';
 
 const TIMEOUT_DURATION = 5000; // 5 seconds
 


### PR DESCRIPTION
This pull request introduces two key updates: one to improve database connection pooling in the backend and another to enhance the flexibility of API URL configuration in the frontend.

### Backend changes:
* Added a `CONN_MAX_AGE` setting in `RubikLog/settings.py` to enable database connection pooling, keeping connections alive for 10 minutes. This can improve performance by reducing the overhead of establishing new connections.

### Frontend changes:
* Updated `API_URL` in `frontend/src/App.jsx` to use the `REACT_APP_API_URL` environment variable if available, providing greater flexibility for API endpoint configuration across environments. The fallback remains the local development URL.