### PR TITLE
chore: update CI configuration to use SQLite for testing and adjust settings for frontend build directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,25 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }}
     env:
-      POSTGRES_DB: rubiklogdb
-      POSTGRES_USER: shreyuu
-      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
-      POSTGRES_HOST: dpg-d0hnhot6ubrc73ah6vig-a.oregon-postgres.render.com
-      POSTGRES_PORT: 5432
-      DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
-      DJANGO_DEBUG: ${{ github.ref != 'refs/heads/main' }}
-      DJANGO_ALLOWED_HOSTS: localhost,127.0.0.1,.oregon-postgres.render.com
+      DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY || 'django-insecure-key-for-testing-only' }}
+      DJANGO_DEBUG: true
+      DJANGO_ALLOWED_HOSTS: localhost,127.0.0.1
+      USE_SQLITE_FOR_TESTING: true # Add this flag to use SQLite during tests
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Debug env (without sensitive values)
-        run: |
-          echo "POSTGRES_USER: $POSTGRES_USER"
-          echo "POSTGRES_HOST: $POSTGRES_HOST"
-          echo "POSTGRES_PASSWORD is set: ${POSTGRES_PASSWORD:+yes}"
-          echo "Current environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }}"
-          echo "Debug mode: ${{ github.ref != 'refs/heads/main' }}"
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -44,13 +32,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Run migrations
-        run: |
-          python manage.py migrate
-
       - name: Run backend tests
         run: |
-          python manage.py test --noinput --keepdb
+          python manage.py test --noinput
 
   frontend:
     name: Frontend CI

--- a/RubikLog/settings.py
+++ b/RubikLog/settings.py
@@ -92,7 +92,7 @@ WSGI_APPLICATION = "RubikLog.wsgi.application"
 # https://docs.djangoproject.com/en/5.1/ref/settings/#databases
 
 # Use SQLite for tests, PostgreSQL for development/production
-if TESTING:
+if TESTING or get_env_value("USE_SQLITE_FOR_TESTING", "False") == "True":
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.sqlite3",
@@ -140,9 +140,12 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.1/howto/static-files/
 STATIC_URL = "/static/"
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
-STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, "frontend/build/static"),
-]
+
+# Check if frontend build directory exists before adding it to STATICFILES_DIRS
+FRONTEND_BUILD_DIR = os.path.join(BASE_DIR, "frontend/build/static")
+STATICFILES_DIRS = []
+if os.path.exists(FRONTEND_BUILD_DIR):
+    STATICFILES_DIRS.append(FRONTEND_BUILD_DIR)
 
 # Default primary key field type
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,11 +7,15 @@ gunicorn>=21.2.0
 Pillow>=10.2.0
 numpy>=1.26.4
 opencv-python-headless>=4.9.0.80
-tensorflow-cpu>=2.15.0
 drf-yasg>=1.21.7,<2.0.0
-django-filter>=23.5
+django-filter>=23.5,<24.0
 scikit-learn>=1.4.1
 asgiref>=3.8.1
 sqlparse>=0.5.3
 pytz>=2024.2
 django-db-connection-pool>=1.2.0
+tensorflow-cpu>=2.15.0
+
+# For M1/M2 Macs, install separately:
+# pip install tensorflow-macos tensorflow-metal
+


### PR DESCRIPTION
This pull request introduces changes to streamline the testing setup by switching to SQLite for tests, improve configuration flexibility, and handle static files more robustly. Key updates include modifications to the CI workflow, database configuration, and static file handling.

### CI Workflow Changes:
* Removed PostgreSQL environment variables and replaced them with a flag (`USE_SQLITE_FOR_TESTING`) to use SQLite during tests, simplifying the test setup. (`.github/workflows/ci.yml`, [.github/workflows/ci.ymlL17-L36](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL17-L36))
* Eliminated the migration step in the CI workflow since SQLite does not require migrations for testing, and updated the test command to remove the `--keepdb` flag. (`.github/workflows/ci.yml`, [.github/workflows/ci.ymlL47-R37](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL47-R37))

### Database Configuration:
* Updated `RubikLog/settings.py` to use SQLite for testing when the `USE_SQLITE_FOR_TESTING` environment variable is set to `True`, enhancing flexibility for local and CI environments. (`RubikLog/settings.py`, [RubikLog/settings.pyL95-R95](diffhunk://#diff-80970606968a5cb98c92ad584594397231febc5f1fa4d843b49671bcbb76769dL95-R95))

### Static File Handling:
* Modified `STATICFILES_DIRS` in `RubikLog/settings.py` to dynamically check for the existence of the frontend build directory before including it, preventing potential errors in environments where the directory is missing. (`RubikLog/settings.py`, [RubikLog/settings.pyL143-R148](diffhunk://#diff-80970606968a5cb98c92ad584594397231febc5f1fa4d843b49671bcbb76769dL143-R148))