### PR TITLE
fix: Update cube_type assignment in SolveTests to use the object directly

### DIFF
--- a/tracker/tests.py
+++ b/tracker/tests.py
@@ -73,7 +73,7 @@ class SolveTests(TestCase):
         self.solve_data = {
             "time_taken": 10.5,
             "scramble": "R U R' U'",
-            "cube_type": self.cube_type.pk,
+            "cube_type": self.cube_type,
         }
         self.url = reverse("solve-list")
         # Enable scramble validation skipping by default for most tests


### PR DESCRIPTION
This pull request includes a small change in the `tracker/tests.py` file. The change updates the `solve_data` dictionary in the `setUp` method to directly use the `cube_type` object instead of its primary key (`pk`). 

This adjustment may simplify the test setup and improve readability.