### PR TITLE
refactor: Update API URL structure and organize health check endpoints under a versioned API path

### DIFF
--- a/RubikLog/urls.py
+++ b/RubikLog/urls.py
@@ -34,14 +34,11 @@ schema_view = get_schema_view(
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("api/", include("tracker.urls")),
-    path(
-        "api/docs/",
-        schema_view.with_ui("swagger", cache_timeout=0),
-        name="schema-swagger-ui",
-    ),
-    # Health check endpoints
-    path("health/", health_check, name="health-check"),
-    path("ready/", readiness_check, name="readiness-check"),
-    path("alive/", liveness_check, name="liveness-check"),
+    path("api/v1/", include(([
+        path("", include("tracker.urls")),
+        path("docs/", schema_view.with_ui("swagger", cache_timeout=0), name="schema-swagger-ui"),
+        path("health/", health_check, name="health-check"),
+        path("ready/", readiness_check, name="readiness-check"),
+        path("alive/", liveness_check, name="liveness-check"),
+    ], "api"))),
 ]

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,7 +7,7 @@ import { generateScrambleFromColors } from "./utils/cubeNotation";
 import ScrambleVisualizer from './components/ScrambleVisualizer';
 
 // Update API_URL to use relative path
-const API_URL = process.env.REACT_APP_API_URL || 'http://127.0.0.1:8000/api';
+const API_URL = process.env.REACT_APP_API_URL || 'http://127.0.0.1:8000/api/v1';
 
 const TIMEOUT_DURATION = 15000; // 15 seconds
 const MAX_RETRIES = 3;


### PR DESCRIPTION
This pull request introduces changes to version the API under `/api/v1` and updates related references in both backend and frontend code. These changes aim to improve API organization and maintainability.

### Backend changes:
* Modified `urlpatterns` in `RubikLog/urls.py` to version the API under `/api/v1/` by nesting all API-related paths, including `tracker.urls`, Swagger documentation, and health check endpoints, under this versioned namespace.

### Frontend changes:
* Updated the `API_URL` constant in `frontend/src/App.jsx` to reflect the new versioned API path (`/api/v1`) instead of the previous `/api`.