### PR TITLE
refactor: Update API endpoint references to include namespace for consistency across tests

### DIFF
--- a/tracker/test_api_integration.py
+++ b/tracker/test_api_integration.py
@@ -26,7 +26,7 @@ class APIIntegrationTests(TestCase):
         solve_id = json.loads(create_response.content)["id"]
 
         # Read
-        detail_url = reverse("solve-detail", kwargs={"pk": solve_id})
+        detail_url = reverse("api:solve-detail", kwargs={"pk": solve_id})
         read_response = self.client.get(detail_url)
         self.assertEqual(read_response.status_code, status.HTTP_200_OK)
         read_data = json.loads(read_response.content)
@@ -80,7 +80,7 @@ class APIIntegrationTests(TestCase):
         results = data["results"]
         times = [solve["time_taken"] for solve in results]
         self.assertEqual(times, sorted(times))
-        response = self.client.get(reverse("solve-detail", kwargs={"pk": 999}))
+        response = self.client.get(reverse("api:solve-detail", kwargs={"pk": 999}))
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
         # Test validation errors
@@ -89,7 +89,7 @@ class APIIntegrationTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_cube_scan_endpoint(self):
-        scan_url = reverse("scan-cube")
+        scan_url = reverse("api:scan-cube")
 
         # Test with missing image data
         response = self.client.post(scan_url, {}, format="json")

--- a/tracker/tests.py
+++ b/tracker/tests.py
@@ -113,7 +113,7 @@ class SolveTests(TestCase):
 
     def test_delete_solve(self):
         solve = Solve.objects.create(**self.solve_model_data)
-        url = reverse("solve-detail", kwargs={"pk": solve.pk})
+        url = reverse("api:solve-detail", kwargs={"pk": solve.pk})
         response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(Solve.objects.count(), 0)
@@ -146,7 +146,7 @@ class SolveTests(TestCase):
 
     def test_get_single_solve(self):
         solve = Solve.objects.create(**self.solve_model_data)
-        url = reverse("solve-detail", kwargs={"pk": solve.pk})
+        url = reverse("api:solve-detail", kwargs={"pk": solve.pk})
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["time_taken"], solve.time_taken)


### PR DESCRIPTION
This pull request updates API endpoint references across multiple test cases to use the correct namespace (`api`). These changes ensure consistency and accuracy when resolving URLs for API endpoints.

### Updates to API endpoint references:

* `tracker/test_api_integration.py`:
  - Updated the `reverse` function calls in `test_full_crud_workflow` and `test_filtering_and_sorting` to include the `api` namespace for `solve-detail` and `scan-cube` endpoints. [[1]](diffhunk://#diff-342966add360e22faee179e44eafb55c03aaeedd783956aaa25e320d5249ca2cL29-R29) [[2]](diffhunk://#diff-342966add360e22faee179e44eafb55c03aaeedd783956aaa25e320d5249ca2cL83-R83) [[3]](diffhunk://#diff-342966add360e22faee179e44eafb55c03aaeedd783956aaa25e320d5249ca2cL92-R92)

* `tracker/tests.py`:
  - Updated the `reverse` function calls in `test_create_solve` and `test_get_solves` to include the `api` namespace for the `solve-detail` endpoint. [[1]](diffhunk://#diff-4eb165970c8e3025eb91fd0369e4a18ca22306b10f316a28abca97a9d180b38dL116-R116) [[2]](diffhunk://#diff-4eb165970c8e3025eb91fd0369e4a18ca22306b10f316a28abca97a9d180b38dL149-R149)